### PR TITLE
Add unit conversions and mph support for speed sensors

### DIFF
--- a/Guides/HOME-ASSISTANT.md
+++ b/Guides/HOME-ASSISTANT.md
@@ -25,12 +25,22 @@ Replace `iracing` (default) with the MQTT topic prefix you configured in the iR2
 mqtt:
   sensor:
 
-    # Speed sensor - car speed in km/h
-    - name: "iR2mqtt Speed"
-      unique_id: iracing_speed
+    # Speed sensor - car speed in m/s
+    - name: "iR2mqtt Speed m/s"
+      unique_id: iracing_speed_ms
       state_topic: "iracing/telemetry"
       value_template: "{{ value_json.speed | float | round(1) }}"
-      unit_of_measurement: "mph"
+      unit_of_measurement: "km/h"
+      device_class: "speed"
+      icon: mdi:speedometer
+      expire_after: 30
+
+    # Speed sensor - car speed in km/h
+    - name: "iR2mqtt Speed km/h"
+      unique_id: iracing_speed_kmh
+      state_topic: "iracing/telemetry"
+      value_template: "{{ (value_json.speed | float * 3.6) | round(1) }}"
+      unit_of_measurement: "km/h"
       device_class: "speed"
       icon: mdi:speedometer
       expire_after: 30

--- a/Guides/HOME-ASSISTANT.md
+++ b/Guides/HOME-ASSISTANT.md
@@ -30,17 +30,27 @@ mqtt:
       unique_id: iracing_speed_ms
       state_topic: "iracing/telemetry"
       value_template: "{{ value_json.speed | float | round(1) }}"
-      unit_of_measurement: "km/h"
+      unit_of_measurement: "m/s"
       device_class: "speed"
       icon: mdi:speedometer
       expire_after: 30
-
+      
     # Speed sensor - car speed in km/h
     - name: "iR2mqtt Speed km/h"
       unique_id: iracing_speed_kmh
       state_topic: "iracing/telemetry"
       value_template: "{{ (value_json.speed | float * 3.6) | round(1) }}"
       unit_of_measurement: "km/h"
+      device_class: "speed"
+      icon: mdi:speedometer
+      expire_after: 30
+      
+    # Speed sensor - car speed in mph
+    - name: "iR2mqtt Speed mph"
+      unique_id: iracing_speed_mph
+      state_topic: "iracing/telemetry"
+      value_template: "{{ (value_json.speed | float * 2.237) | round(1) }}"
+      unit_of_measurement: "mph"
       device_class: "speed"
       icon: mdi:speedometer
       expire_after: 30
@@ -300,7 +310,7 @@ binary_sensor:
       ir2mqtt_on_pit_road:
         friendly_name: "iR2MQTT On Pit Road"
         value_template: "{{ is_state('sensor.iracing_on_pit_road_raw', 'True') }}"
-        icon_template: mdi:pit
+        icon_template: mdi:gauge
 
 # ===========================
 # End of iR2mqtt sensors

--- a/Guides/yaml/sensors-example.yaml
+++ b/Guides/yaml/sensors-example.yaml
@@ -9,17 +9,27 @@ mqtt:
       unique_id: iracing_speed_ms
       state_topic: "iracing/telemetry"
       value_template: "{{ value_json.speed | float | round(1) }}"
-      unit_of_measurement: "km/h"
+      unit_of_measurement: "m/s"
       device_class: "speed"
       icon: mdi:speedometer
       expire_after: 30
-
+      
     # Speed sensor - car speed in km/h
     - name: "iR2mqtt Speed km/h"
       unique_id: iracing_speed_kmh
       state_topic: "iracing/telemetry"
       value_template: "{{ (value_json.speed | float * 3.6) | round(1) }}"
       unit_of_measurement: "km/h"
+      device_class: "speed"
+      icon: mdi:speedometer
+      expire_after: 30
+      
+    # Speed sensor - car speed in mph
+    - name: "iR2mqtt Speed mph"
+      unique_id: iracing_speed_mph
+      state_topic: "iracing/telemetry"
+      value_template: "{{ (value_json.speed | float * 2.237) | round(1) }}"
+      unit_of_measurement: "mph"
       device_class: "speed"
       icon: mdi:speedometer
       expire_after: 30

--- a/Guides/yaml/sensors-example.yaml
+++ b/Guides/yaml/sensors-example.yaml
@@ -4,11 +4,21 @@
 mqtt:
   sensor:
 
-    # Speed sensor - car speed in km/h
-    - name: "iR2mqtt Speed"
-      unique_id: iracing_speed
+    # Speed sensor - car speed in m/s
+    - name: "iR2mqtt Speed m/s"
+      unique_id: iracing_speed_ms
       state_topic: "iracing/telemetry"
       value_template: "{{ value_json.speed | float | round(1) }}"
+      unit_of_measurement: "km/h"
+      device_class: "speed"
+      icon: mdi:speedometer
+      expire_after: 30
+
+    # Speed sensor - car speed in km/h
+    - name: "iR2mqtt Speed km/h"
+      unique_id: iracing_speed_kmh
+      state_topic: "iracing/telemetry"
+      value_template: "{{ (value_json.speed | float * 3.6) | round(1) }}"
       unit_of_measurement: "km/h"
       device_class: "speed"
       icon: mdi:speedometer


### PR DESCRIPTION
Thank you for this excellent project! As the author of [WindScape](https://github.com/TilmanGriesel/WindScape), I wanted to integrate my Noctua NV-FS1 Desk and Room Fan as a driving wind simulator for VR racing.

While implementing this integration, I discovered that the current example publishes speed values directly from the iRacing API in meters per second, but the km/h conversion was missing the required multiplication by 3.6.

**Changes made:**
- Fixed km/h conversion by adding the missing 3.6 multiplier
- Added mph sensor for broader compatibility
- Users can now use all three speed units (m/s, km/h, mph)

